### PR TITLE
feat(solution/cloud-migration): 为 RabbitMQ Serverless 模板添加服务关联角色和 Pri…

### DIFF
--- a/documents/solution/cloud-migration/rabbitmq-serverless.tf.yml
+++ b/documents/solution/cloud-migration/rabbitmq-serverless.tf.yml
@@ -89,6 +89,40 @@ Workspace:
       vpc_id = alicloud_vpc.default.id
     }
 
+    # 创建 RabbitMQ 服务关联角色：
+    # - AliyunServiceRoleForAmqpNetwork：实例通过 PrivateLink 接入 VPC 时必需
+    # - AliyunServiceRoleForAmqpMonitoring：support_tracing=true 启用监控/Dashboard 时必需
+    # 首次在新账号下创建实例时，若未提前创建上述 SLR，AMQP 后端会返回
+    # "请先创建服务关联角色 (the role doesn't exist)" 错误。
+    # 开通私网连接（PrivateLink）服务：RabbitMQ Serverless 通过 PrivateLink 接入 VPC，
+    # 账号未激活该产品时 AMQP 后端会返回
+    # "user doesn't activate pvl product / 当前用户未激活私网接入点产品"。
+    # 该 data 源会幂等地激活 PrivateLink；已开通则直接返回开通状态。
+    data "alicloud_privatelink_service" "open" {
+      enable = "On"
+    }
+
+    # 通过 data 源探测角色是否已存在，避免重复创建时返回 EntityAlreadyExists.Role。
+    # 使用 (?i) 大小写不敏感匹配，因为后端实际下发的角色名可能是 AMQP 全大写
+    # （如 AliyunServiceRoleForAMQPNetwork），而文档中写作 Amqp 混合大小写。
+    data "alicloud_ram_roles" "amqp_network_check" {
+      name_regex = "(?i)^AliyunServiceRoleForAmqpNetwork$"
+    }
+
+    data "alicloud_ram_roles" "amqp_monitoring_check" {
+      name_regex = "(?i)^AliyunServiceRoleForAmqpMonitoring$"
+    }
+
+    resource "alicloud_resource_manager_service_linked_role" "amqp_network" {
+      count        = length(data.alicloud_ram_roles.amqp_network_check.roles) == 0 ? 1 : 0
+      service_name = "network.amqp.aliyuncs.com"
+    }
+
+    resource "alicloud_resource_manager_service_linked_role" "amqp_monitoring" {
+      count        = length(data.alicloud_ram_roles.amqp_monitoring_check.roles) == 0 ? 1 : 0
+      service_name = "monitoring.amqp.aliyuncs.com"
+    }
+
     # 创建一个RAM用户
     resource "alicloud_ram_user" "ram_user" {
       name = "create-by-solution-${local.common_name}"
@@ -137,6 +171,14 @@ Workspace:
       vpc_id                 = alicloud_vpc.default.id
       vswitch_ids            = [alicloud_vswitch.vsw1.id, alicloud_vswitch.vsw2.id]
       security_group_id      = alicloud_security_group.default.id
+
+      depends_on = [
+        data.alicloud_privatelink_service.open,
+        data.alicloud_ram_roles.amqp_network_check,
+        data.alicloud_ram_roles.amqp_monitoring_check,
+        alicloud_resource_manager_service_linked_role.amqp_network,
+        alicloud_resource_manager_service_linked_role.amqp_monitoring,
+      ]
     }
 
     resource "alicloud_amqp_static_account" "default" {

--- a/documents/solution/cloud-migration/rabbitmq-serverless_intl_en.tf.yml
+++ b/documents/solution/cloud-migration/rabbitmq-serverless_intl_en.tf.yml
@@ -89,6 +89,41 @@ Workspace:
       vpc_id = alicloud_vpc.default.id
     }
 
+    # Create RabbitMQ service-linked roles:
+    # - AliyunServiceRoleForAmqpNetwork: required when the instance accesses the VPC via PrivateLink
+    # - AliyunServiceRoleForAmqpMonitoring: required when support_tracing=true enables monitoring/Dashboard
+    # When a brand-new account creates an AMQP instance for the first time without these SLRs,
+    # the AMQP backend returns "the role doesn't exist (please create the service-linked role first)".
+    # The data sources probe whether the roles already exist (case-insensitive, because the actual
+    # role name may be AliyunServiceRoleForAMQPNetwork while docs use Amqp), so re-runs do not
+    # fail with EntityAlreadyExists.Role.
+
+    # Activate the PrivateLink service: RabbitMQ Serverless accesses the VPC via PrivateLink,
+    # and the AMQP backend returns "user doesn't activate pvl product" when the account has not
+    # activated PrivateLink. This data source idempotently opens the service; if it is already
+    # opened, it simply returns the existing status.
+    data "alicloud_privatelink_service" "open" {
+      enable = "On"
+    }
+
+    data "alicloud_ram_roles" "amqp_network_check" {
+      name_regex = "(?i)^AliyunServiceRoleForAmqpNetwork$"
+    }
+
+    data "alicloud_ram_roles" "amqp_monitoring_check" {
+      name_regex = "(?i)^AliyunServiceRoleForAmqpMonitoring$"
+    }
+
+    resource "alicloud_resource_manager_service_linked_role" "amqp_network" {
+      count        = length(data.alicloud_ram_roles.amqp_network_check.roles) == 0 ? 1 : 0
+      service_name = "network.amqp.aliyuncs.com"
+    }
+
+    resource "alicloud_resource_manager_service_linked_role" "amqp_monitoring" {
+      count        = length(data.alicloud_ram_roles.amqp_monitoring_check.roles) == 0 ? 1 : 0
+      service_name = "monitoring.amqp.aliyuncs.com"
+    }
+
     # Create a RAM user
     resource "alicloud_ram_user" "ram_user" {
       name = "create-by-solution-${local.common_name}"
@@ -137,6 +172,14 @@ Workspace:
       vpc_id                 = alicloud_vpc.default.id
       vswitch_ids            = [alicloud_vswitch.vsw1.id, alicloud_vswitch.vsw2.id]
       security_group_id      = alicloud_security_group.default.id
+
+      depends_on = [
+        data.alicloud_privatelink_service.open,
+        data.alicloud_ram_roles.amqp_network_check,
+        data.alicloud_ram_roles.amqp_monitoring_check,
+        alicloud_resource_manager_service_linked_role.amqp_network,
+        alicloud_resource_manager_service_linked_role.amqp_monitoring,
+      ]
     }
 
     resource "alicloud_amqp_static_account" "default" {

--- a/documents/solution/cloud-migration/rabbitmq-serverless_intl_zh.tf.yml
+++ b/documents/solution/cloud-migration/rabbitmq-serverless_intl_zh.tf.yml
@@ -89,6 +89,40 @@ Workspace:
       vpc_id = alicloud_vpc.default.id
     }
 
+    # 创建 RabbitMQ 服务关联角色：
+    # - AliyunServiceRoleForAmqpNetwork：实例通过 PrivateLink 接入 VPC 时必需
+    # - AliyunServiceRoleForAmqpMonitoring：support_tracing=true 启用监控/Dashboard 时必需
+    # 首次在新账号下创建实例时，若未提前创建上述 SLR，AMQP 后端会返回
+    # "请先创建服务关联角色 (the role doesn't exist)" 错误。
+    # 开通私网连接（PrivateLink）服务：RabbitMQ Serverless 通过 PrivateLink 接入 VPC，
+    # 账号未激活该产品时 AMQP 后端会返回
+    # "user doesn't activate pvl product / 当前用户未激活私网接入点产品"。
+    # 该 data 源会幂等地激活 PrivateLink；已开通则直接返回开通状态。
+    data "alicloud_privatelink_service" "open" {
+      enable = "On"
+    }
+
+    # 通过 data 源探测角色是否已存在，避免重复创建时返回 EntityAlreadyExists.Role。
+    # 使用 (?i) 大小写不敏感匹配，因为后端实际下发的角色名可能是 AMQP 全大写
+    # （如 AliyunServiceRoleForAMQPNetwork），而文档中写作 Amqp 混合大小写。
+    data "alicloud_ram_roles" "amqp_network_check" {
+      name_regex = "(?i)^AliyunServiceRoleForAmqpNetwork$"
+    }
+
+    data "alicloud_ram_roles" "amqp_monitoring_check" {
+      name_regex = "(?i)^AliyunServiceRoleForAmqpMonitoring$"
+    }
+
+    resource "alicloud_resource_manager_service_linked_role" "amqp_network" {
+      count        = length(data.alicloud_ram_roles.amqp_network_check.roles) == 0 ? 1 : 0
+      service_name = "network.amqp.aliyuncs.com"
+    }
+
+    resource "alicloud_resource_manager_service_linked_role" "amqp_monitoring" {
+      count        = length(data.alicloud_ram_roles.amqp_monitoring_check.roles) == 0 ? 1 : 0
+      service_name = "monitoring.amqp.aliyuncs.com"
+    }
+
     # 创建一个RAM用户
     resource "alicloud_ram_user" "ram_user" {
       name = "create-by-solution-${local.common_name}"
@@ -137,6 +171,14 @@ Workspace:
       vpc_id                 = alicloud_vpc.default.id
       vswitch_ids            = [alicloud_vswitch.vsw1.id, alicloud_vswitch.vsw2.id]
       security_group_id      = alicloud_security_group.default.id
+
+      depends_on = [
+        data.alicloud_privatelink_service.open,
+        data.alicloud_ram_roles.amqp_network_check,
+        data.alicloud_ram_roles.amqp_monitoring_check,
+        alicloud_resource_manager_service_linked_role.amqp_network,
+        alicloud_resource_manager_service_linked_role.amqp_monitoring,
+      ]
     }
 
     resource "alicloud_amqp_static_account" "default" {


### PR DESCRIPTION
…vateLink 前置依赖

新账号首次创建 AMQP 实例时需要预先创建 SLR 并开通 PrivateLink，否则后端会报错。 本次变更在三个模板（国内站、国际站中文、国际站英文）中统一添加了幂等的 SLR 创建逻辑和 depends_on 依赖声明。